### PR TITLE
Close Chrome browser through the XBMC remote

### DIFF
--- a/default.py
+++ b/default.py
@@ -209,7 +209,7 @@ def killBrowser():
         else:
             browserPID = -1
         if browserPID > 0:
-            os.kill(browserPID, signal.SIGKILL)
+            os.kill(browserPID, signal.SIGTERM)
             os.unlink(browserPIDFile)
 
 

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -15,4 +15,5 @@
   <string id="30014">Script path</string>
   <string id="30015">Delay after script (in seconds)</string>
   <string id="30016">Use kiosk mode?</string>
+  <string id="30017">Click "OK" to close Chrome</string>
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -12,4 +12,5 @@
   <string id="30013">Benutzerdefiniertes Skript vor Chrome starten</string>
   <string id="30014">Script Pfad</string>
   <string id="30015">Pause nach Skript (in Sekunden)</string>
+  <string id="30017">Klicken Sie auf OK, um Chrom zu schließen</string>
 </strings>


### PR DESCRIPTION
This patch allows the user to close the Chrome browser by pressing "SELECT" on the XBMC remote (web control, lirc, etc.) instead of Alt-F4, CMD-Q, etc.  This makes it a bit easier to control your viewing without a full mouse + keyboard setup.  I've only tested this on Linux, but it should work equally well on Mac OS X, however Windows will require some additional work since it does not have the UNIX "ps" and "grep" commands and I do not have a Windows test environment.  The included stub code _might_ work, but it would kill all Chrome windows, not just the one opened by XBMC.  This code is compatible with existing plugins that utilize the Chrome Launcher (i.e., NetfliXBMC and Amazon Chrome Launcher), and will close the Chrome browser on those plugins in the same manner without any additional changes to their code.
